### PR TITLE
start handling plugins

### DIFF
--- a/polars_to_ibis/_parse/table_handlers.py
+++ b/polars_to_ibis/_parse/table_handlers.py
@@ -113,18 +113,6 @@ def handle_select(payload: PolarsPlan, table: ir.Table) -> ir.Table:
 
     match payload:
         case {
-            "expr": ["Len"],
-            "options": {
-                "duplicate_check": True,
-                "run_parallel": True,
-                "should_broadcast": True,
-            },
-            **extras,
-        }:
-            assert_no_extras(extras)
-            # TODO: This feels like a kludge:
-            return input_table.select(len=input_table.count()).head(1)
-        case {
             "expr": expr,
             "options": {
                 "duplicate_check": True,
@@ -134,14 +122,42 @@ def handle_select(payload: PolarsPlan, table: ir.Table) -> ir.Table:
             **extras,
         }:
             assert_no_extras(extras)
+        case _:  # pragma: no cover
+            raise NotImplementedError(f"Unsupported Select: {payload}")
+
+    match expr:
+        case ["Len"]:
+            # TODO: This feels like a kludge:
+            return input_table.select(len=input_table.count()).head(1)
+        case [
+            {
+                "Function": {
+                    "input": [{"Literal": {"Scalar": {"Null": "Null"}}}],
+                    "function": {
+                        "FfiPlugin": {
+                            "flags": {
+                                "check_lengths": True,
+                                "flags": "RETURNS_SCALAR | LENGTH_PRESERVING",
+                            },
+                            "lib": _,
+                            "symbol": "dp_frame_len",
+                            "kwargs": [],
+                        }
+                    },
+                }
+            }
+        ]:
+            # TODO: Find a side-channel to return the opendp plugin information.
+            # TODO: Handle more OpenDP expressions.
+            # TODO: This is the same kludge as above!
+            return input_table.select(len=input_table.count()).head(1)
+        case _:
             select_kwargs, drop_args = parse_select_expr(expr)  # type: ignore
             if select_kwargs:
                 input_table = input_table.select(**select_kwargs)  # type: ignore
             if drop_args:
                 input_table = input_table.drop(*drop_args)  # type: ignore
             return input_table
-        case _:  # pragma: no cover
-            raise NotImplementedError(f"Unsupported Select: {payload}")
 
 
 @table_handler("Filter")

--- a/polars_to_ibis/_parse/table_handlers.py
+++ b/polars_to_ibis/_parse/table_handlers.py
@@ -293,7 +293,7 @@ def handle_group_by(payload: PolarsPlan, table: ir.Table) -> ir.Table:
     match payload:
         case {
             "keys": keys,
-            "aggs": [{"Agg": agg_payload}],
+            "aggs": aggs,
             "maintain_order": False,
             "options": {"dynamic": None, "rolling": None, "slice": None},
             **extras,
@@ -304,15 +304,24 @@ def handle_group_by(payload: PolarsPlan, table: ir.Table) -> ir.Table:
             assert_no_extras(extras)
             group_by_keys = parse_sort_by_column(keys)
             grouped_table = input_table.group_by(group_by_keys)
-            agg_payload_tag, agg_payload_payload = split_tag_payload(agg_payload)
         case _:  # pragma: no cover
             raise NotImplementedError("Unsupported GroupBy")
+
+    if len(aggs) > 1:
+        raise NotImplementedError("Unsupported len(aggs) > 1")
+
+    agg_tag, agg_payload = split_tag_payload(aggs[0])
+    match agg_tag:
+        case "Agg":
+            agg_payload_tag, agg_payload_payload = split_tag_payload(agg_payload)
+        case _:  # pragma: no cover
+            raise NotImplementedError("Unsupported GroupBy aggs")
 
     match agg_payload_payload:
         case {"Column": column, **extras}:
             assert_no_extras(extras)
         case _:  # pragma: no cover
-            raise NotImplementedError("Unsupported GroupBy")
+            raise NotImplementedError("Unsupported GroupBy Agg")
 
     match agg_payload_tag:
         case "Sum" | "Mean" | "Median" | "Max" | "Min":

--- a/polars_to_ibis/_parse/table_handlers.py
+++ b/polars_to_ibis/_parse/table_handlers.py
@@ -110,12 +110,38 @@ def handle_scan(payload: PolarsPlan, table: ir.Table) -> ir.Table:
 @table_handler("Select")
 def handle_select(payload: PolarsPlan, table: ir.Table) -> ir.Table:
     input_table = update_polars_to_ibis(payload["input"], table=table)
-    select_kwargs, drop_args = parse_select_expr(payload["expr"])  # type: ignore
-    if select_kwargs:
-        input_table = input_table.select(**select_kwargs)  # type: ignore
-    if drop_args:
-        input_table = input_table.drop(*drop_args)  # type: ignore
-    return input_table
+
+    match payload:
+        case {
+            "expr": ["Len"],
+            "options": {
+                "duplicate_check": True,
+                "run_parallel": True,
+                "should_broadcast": True,
+            },
+            **extras,
+        }:
+            assert_no_extras(extras)
+            # TODO: This feels like a kludge:
+            return input_table.select(len=input_table.count()).head(1)
+        case {
+            "expr": expr,
+            "options": {
+                "duplicate_check": True,
+                "run_parallel": True,
+                "should_broadcast": True,
+            },
+            **extras,
+        }:
+            assert_no_extras(extras)
+            select_kwargs, drop_args = parse_select_expr(expr)  # type: ignore
+            if select_kwargs:
+                input_table = input_table.select(**select_kwargs)  # type: ignore
+            if drop_args:
+                input_table = input_table.drop(*drop_args)  # type: ignore
+            return input_table
+        case _:  # pragma: no cover
+            raise NotImplementedError(f"Unsupported Select: {payload}")
 
 
 @table_handler("Filter")

--- a/polars_to_ibis/_parse/table_handlers.py
+++ b/polars_to_ibis/_parse/table_handlers.py
@@ -286,6 +286,25 @@ def handle_hstack(payload: PolarsPlan, table: ir.Table) -> ir.Table:
             raise NotImplementedError(f"Unsupported HStack function: {function}")
 
 
+@table_handler("Function")
+def handle_function(payload: PolarsPlan, table: ir.Table) -> ir.Table:
+    match payload:
+        case {
+            "function": {
+                "FfiPlugin": {
+                    "flags": _,
+                    "kwargs": _,
+                    "lib": _,
+                    "symbol": _,
+                }
+            },
+            "input": _,
+        }:
+            raise Exception("TODO: FFI!")
+        case _:
+            raise NotImplementedError("Unsupported Function")
+
+
 @table_handler("GroupBy")
 def handle_group_by(payload: PolarsPlan, table: ir.Table) -> ir.Table:
     input_table = update_polars_to_ibis(payload["input"], table=table)
@@ -314,6 +333,8 @@ def handle_group_by(payload: PolarsPlan, table: ir.Table) -> ir.Table:
     match agg_tag:
         case "Agg":
             agg_payload_tag, agg_payload_payload = split_tag_payload(agg_payload)
+        case "Function":
+            return update_polars_to_ibis(aggs[0], table=table)
         case _:  # pragma: no cover
             raise NotImplementedError("Unsupported GroupBy aggs")
 

--- a/polars_to_ibis/_parse/table_handlers.py
+++ b/polars_to_ibis/_parse/table_handlers.py
@@ -2,6 +2,7 @@
 This is a private module: The API may change.
 """
 
+from json import dumps
 from typing import Any, Callable
 
 import ibis  # pyright: ignore [reportMissingTypeStubs]
@@ -147,10 +148,12 @@ def handle_select(payload: PolarsPlan, table: ir.Table) -> ir.Table:
                 }
             }
         ]:
-            # TODO: Find a side-channel to return the opendp plugin information.
             # TODO: Handle more OpenDP expressions.
             # TODO: This is the same kludge as above!
-            return input_table.select(len=input_table.count()).head(1)
+            return input_table.select(
+                len=input_table.count(),
+                expr_json=ibis.literal(dumps(expr, indent=1)),  # type: ignore
+            ).head(1)
         case _:
             select_kwargs, drop_args = parse_select_expr(expr)  # type: ignore
             if select_kwargs:

--- a/polars_to_ibis/_parse/table_handlers.py
+++ b/polars_to_ibis/_parse/table_handlers.py
@@ -150,6 +150,9 @@ def handle_select(payload: PolarsPlan, table: ir.Table) -> ir.Table:
         ]:
             # TODO: Handle more OpenDP expressions.
             # TODO: This is the same kludge as above!
+
+            # Library location is not stable. Remove.
+            del expr[0]["Function"]["function"]["FfiPlugin"]["lib"]
             return input_table.select(
                 len=input_table.count(),
                 expr_json=ibis.literal(dumps(expr, indent=1)),  # type: ignore

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -39,6 +39,7 @@ class Fixture:
     category: str
     expression: str
     expected_output: dict[str, list[float | str]]
+    skip_polars: bool = False
     expected_backend_errors: dict[str, str] = dataclasses.field(default_factory=dict)  # type: ignore
     expected_exporter_errors: dict[str, str] = dataclasses.field(default_factory=dict)  # type: ignore
     tolerance: dict[str, float] = dataclasses.field(default_factory=dict)  # type: ignore
@@ -49,6 +50,16 @@ fixtures = [
         "numeric",
         "lf.select(pl.len())",
         {"len": [4]},
+        expected_backend_errors={
+            "polars": "No translation rule for "
+            "<class 'ibis.expr.operations.window.WindowFunction'>"
+        },
+    ),
+    Fixture(
+        "numeric",
+        "lf.select(dp.len())",
+        {"len": [4]},
+        skip_polars=True,
         expected_backend_errors={
             "polars": "No translation rule for "
             "<class 'ibis.expr.operations.window.WindowFunction'>"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -40,6 +40,7 @@ class Fixture:
     expression: str
     expected_output: dict[str, list[float | str]]
     uses_plugin: bool = False
+    expected_conversion_error: str | None = None
     expected_backend_errors: dict[str, str] = dataclasses.field(default_factory=dict)  # type: ignore
     expected_exporter_errors: dict[str, str] = dataclasses.field(default_factory=dict)  # type: ignore
     tolerance: dict[str, float] = dataclasses.field(default_factory=dict)  # type: ignore
@@ -286,12 +287,13 @@ fixtures = [
         "lf.group_by('keys').agg(pl.col('values').sum()).sort(by='keys').select('values').head(1)",
         {"values": [3]},
     ),
-    # Fixture(
-    #     "grouping",
-    #     "lf.group_by('keys').agg(pl.col('values').dp.sum(bounds=(0,1))).sort(by='keys')",
-    #     {"values": [3]},
-    #     uses_plugin=True,
-    # ),
+    Fixture(
+        "grouping",
+        "lf.group_by('keys').agg(pl.col('values').dp.sum(bounds=(0,1))).sort(by='keys')",
+        {"values": [3]},
+        uses_plugin=True,
+        expected_conversion_error="TODO: FFI!",
+    ),
     Fixture(
         "grouping",
         "lf.filter(pl.col('values') != 1)",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -45,6 +45,15 @@ class Fixture:
 
 
 fixtures = [
+    Fixture(
+        "numeric",
+        "lf.select(pl.len())",
+        {"len": [4]},
+        expected_backend_errors={
+            "polars": "No translation rule for "
+            "<class 'ibis.expr.operations.window.WindowFunction'>"
+        },
+    ),
     Fixture("numeric", "lf.sum()", {"floats": [1.0], "ints": [10]}),
     Fixture(
         "numeric",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -286,6 +286,12 @@ fixtures = [
         "lf.group_by('keys').agg(pl.col('values').sum()).sort(by='keys').select('values').head(1)",
         {"values": [3]},
     ),
+    # Fixture(
+    #     "grouping",
+    #     "lf.group_by('keys').agg(pl.col('values').dp.sum(bounds=(0,1))).sort(by='keys')",
+    #     {"values": [3]},
+    #     uses_plugin=True,
+    # ),
     Fixture(
         "grouping",
         "lf.filter(pl.col('values') != 1)",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -39,7 +39,7 @@ class Fixture:
     category: str
     expression: str
     expected_output: dict[str, list[float | str]]
-    skip_polars: bool = False
+    uses_plugin: bool = False
     expected_backend_errors: dict[str, str] = dataclasses.field(default_factory=dict)  # type: ignore
     expected_exporter_errors: dict[str, str] = dataclasses.field(default_factory=dict)  # type: ignore
     tolerance: dict[str, float] = dataclasses.field(default_factory=dict)  # type: ignore
@@ -58,8 +58,39 @@ fixtures = [
     Fixture(
         "numeric",
         "lf.select(dp.len())",
-        {"len": [4]},
-        skip_polars=True,
+        {
+            "expr_json": [
+                "[\n"
+                " {\n"
+                '  "Function": {\n'
+                '   "input": [\n'
+                "    {\n"
+                '     "Literal": {\n'
+                '      "Scalar": {\n'
+                '       "Null": "Null"\n'
+                "      }\n"
+                "     }\n"
+                "    }\n"
+                "   ],\n"
+                '   "function": {\n'
+                '    "FfiPlugin": {\n'
+                '     "flags": {\n'
+                '      "check_lengths": true,\n'
+                '      "flags": "RETURNS_SCALAR | LENGTH_PRESERVING"\n'
+                "     },\n"
+                '     "lib": '
+                '"lib/python3.12/site-packages/opendp/lib/opendp.abi3.so",\n'
+                '     "symbol": "dp_frame_len",\n'
+                '     "kwargs": []\n'
+                "    }\n"
+                "   }\n"
+                "  }\n"
+                " }\n"
+                "]",
+            ],
+            "len": [4],
+        },
+        uses_plugin=True,
         expected_backend_errors={
             "polars": "No translation rule for "
             "<class 'ibis.expr.operations.window.WindowFunction'>"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -78,8 +78,6 @@ fixtures = [
                 '      "check_lengths": true,\n'
                 '      "flags": "RETURNS_SCALAR | LENGTH_PRESERVING"\n'
                 "     },\n"
-                '     "lib": '
-                '"lib/python3.12/site-packages/opendp/lib/opendp.abi3.so",\n'
                 '     "symbol": "dp_frame_len",\n'
                 '     "kwargs": []\n'
                 "    }\n"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -68,7 +68,7 @@ exporters = {  # type: ignore
 def test_translate_table(fixture: Fixture, backend: str, exporter_key: str):
     # Sanity check: Does the polars expression have the expected result?
     lf = pl.LazyFrame(input_data[fixture.category])
-    if not fixture.skip_polars:
+    if not fixture.uses_plugin:
         polars_output = eval(fixture.expression).collect().to_dict(as_series=False)
         assert polars_output == fixture.expected_output, "Typo in test?"
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -84,6 +84,12 @@ def test_translate_table(fixture: Fixture, backend: str, exporter_key: str):
     lf = pl.LazyFrame(schema=lf.collect_schema())
     lf = eval(fixture.expression)
     table_name = "default_table"
+    if fixture.expected_conversion_error:
+        with pytest.raises(
+            Exception, match=re.escape(fixture.expected_conversion_error)
+        ):
+            convert_polars_to_ibis(lf, table_name)
+        pytest.xfail(f"expected error: {fixture.expected_conversion_error}")
     ibis_table = convert_polars_to_ibis(lf, table_name)
 
     # Set up target database, with data:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,6 +2,7 @@ import re
 from os import environ
 
 import ibis  # type: ignore
+import opendp.prelude as dp  # type: ignore # noqa: F401
 import polars as pl
 import pytest
 
@@ -67,8 +68,9 @@ exporters = {  # type: ignore
 def test_translate_table(fixture: Fixture, backend: str, exporter_key: str):
     # Sanity check: Does the polars expression have the expected result?
     lf = pl.LazyFrame(input_data[fixture.category])
-    polars_output = eval(fixture.expression).collect().to_dict(as_series=False)
-    assert polars_output == fixture.expected_output, "Typo in test?"
+    if not fixture.skip_polars:
+        polars_output = eval(fixture.expression).collect().to_dict(as_series=False)
+        assert polars_output == fixture.expected_output, "Typo in test?"
 
     # Convert polars to ibis, but without any data:
     lf = pl.LazyFrame(schema=lf.collect_schema())

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -69,7 +69,15 @@ def test_translate_table(fixture: Fixture, backend: str, exporter_key: str):
     # Sanity check: Does the polars expression have the expected result?
     lf = pl.LazyFrame(input_data[fixture.category])
     if not fixture.uses_plugin:
-        polars_output = eval(fixture.expression).collect().to_dict(as_series=False)
+        try:
+            polars_output = eval(fixture.expression).collect().to_dict(as_series=False)
+        except pl.exceptions.ComputeError as e:
+            assert (
+                "OpenDP expressions must be passed through make_private_lazyframe"
+                in str(e)
+            )
+            pytest.fail("Add 'uses_plugin=True' to fixture?")
+
         assert polars_output == fixture.expected_output, "Typo in test?"
 
     # Convert polars to ibis, but without any data:


### PR DESCRIPTION
Draft: Need a place to look at some examples.

I was surprised that the serialization doesn't seem to have a non-dp operation (like sum or mean) followed by the addition of noise as a distinct node: I wonder if the serialization should be desugared before beginning the parse, so this is represented explicitly?

I'm also wondering what we should try to return here: The remaining part of the serialization, with the FFI? Perhaps wrapped up in JSON along with the intermediate result? Or should OpenDP provide callbacks, so that polars-to-ibis can itself apply the noise?

Surfacing another assumption: I would like to keep OpenDP specifics out of this library. I know that you were a bit surprised that I didn't just do this work in the opendp repo, but even just considering the CI matrix, I think it has made sense to keep this distinct, and I think it will continue to help with maintainability if we don't hard-code OpenDP details here.