### PR TITLE
Just overwrite, instead of trying to delete first

### DIFF
--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -37,11 +37,7 @@ Now we'll actually connect to the database, and create a very small table:
 ```python
 >>> import ibis
 >>> connection = ibis.sqlite.connect()
->>> try:  # Ensure a clean slate.
-...     connection.drop_table(table_name)
-... except BaseException:
-...     pass
->>> connection.create_table(table_name, pl.DataFrame({"ints": [1, 2, 3, 4]}))
+>>> connection.create_table(table_name, pl.DataFrame({"ints": [1, 2, 3, 4]}), overwrite=True)
 DatabaseTable: readme_example
   ints int64
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,7 @@ Now we'll actually connect to the database, and create a very small table:
 ```python
 >>> import ibis
 >>> connection = ibis.sqlite.connect()
->>> try:  # Ensure a clean slate.
-...     connection.drop_table(table_name)
-... except BaseException:
-...     pass
->>> connection.create_table(table_name, pl.DataFrame({"ints": [1, 2, 3, 4]}))
+>>> connection.create_table(table_name, pl.DataFrame({"ints": [1, 2, 3, 4]}), overwrite=True)
 DatabaseTable: readme_example
   ints int64
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -25,16 +25,7 @@ def get_connection(df: pl.DataFrame, table_name: str, backend: str):
         else {}
     )
     connection = getattr(ibis, backend).connect(**kwargs)
-
-    # Ensure a clean slate.
-    # Each backend raises its own error type
-    # if the table doesn't already exist.
-    try:
-        connection.drop_table(table_name)
-    except BaseException:  # noqa: B036
-        pass
-    connection.create_table(table_name, df)
-
+    connection.create_table(table_name, df, overwrite=True)
     return connection
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -25,7 +25,17 @@ def get_connection(df: pl.DataFrame, table_name: str, backend: str):
         else {}
     )
     connection = getattr(ibis, backend).connect(**kwargs)
-    connection.create_table(table_name, df, overwrite=True)
+
+    # Ensure a clean slate.
+    # Each backend raises its own error type
+    # if the table doesn't already exist.
+    # NOTE: overwrite=True would be simpler, but not supported by MySQL.
+    try:
+        connection.drop_table(table_name)
+    except BaseException:  # noqa: B036
+        pass
+    connection.create_table(table_name, df)
+
     return connection
 
 


### PR DESCRIPTION
Small simplification to README. (Doesn't work for mysql, so not using in the rest of the tests.)

- Fix #97